### PR TITLE
Hardware page

### DIFF
--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -1,7 +1,7 @@
 {% extends '_layout.html' %} {% block title%} Ubuntu Desktop certified hardware
 {% endblock %} {% block content %}
 
-{{ details }}
+{{ details.release_details }}
 
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
@@ -13,10 +13,8 @@
     <li>&nbsp;›</li>
 
     <li>
-      <a
-        href="https://certification.ubuntu.com/desktop/models/?category=Desktop&amp;category=Laptop&amp;vendors=Dell"
-        >Search Results</a
-      >
+      <a href="https://certification.ubuntu.com/desktop/models/?category=Desktop&amp;category=Laptop&amp;vendors=Dell">Search
+        Results</a>
     </li>
     <li>&nbsp;›</li>
 
@@ -39,13 +37,9 @@
       <h4>Feedback</h4>
       <p>
         If there is an issue with the information for this system, please
-        <a
-          target="_blank"
-          href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the {{
+        <a target="_blank" href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the {{
             details.vendor
-          }} {{ details.name }}"
-          >let us know</a
-        >.
+          }} {{ details.name }}">let us know</a>.
       </p>
     </div>
   </div>
@@ -105,29 +99,22 @@
 
         <table class="definitions">
           <tbody>
+            {% for category, devices in details.release_details.components.items() %}
             <tr>
-              <td class="title">Processor</td>
+              <td style="text-transform: capitalize;" class="title">{{category}}</td>
               <td class="details">
+                {% for device in devices %}
                 <p>
-                  <a
-                    href="/catalog/component/dmi/4103/dmi%3AIntel%28R%29Core%28TM%29i5-7500CPU%403.40GHz/"
-                    >Intel Intel(R) Core(TM) i5-7500 CPU @ 3.40GHz
+                  <a href="/catalog/component/{{ device.bus }}/{{
+                      device.identifier
+                    }}/">{{ device.name }}
+                  </a>
                   </a>
                 </p>
+                {% endfor %}
               </td>
             </tr>
-
-            <tr>
-              <td class="title">Ethernet</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/pci/10ec%3A8168/"
-                    >Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI
-                    Express Gigabit Ethernet Controller
-                  </a>
-                </p>
-              </td>
-            </tr>
+            {% endfor %}
           </tbody>
         </table>
 
@@ -143,11 +130,9 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  <a
-                    href="/catalog/component/{{ device.bus }}/{{
+                  <a href="/catalog/component/{{ device.bus }}/{{
                       device.identifier
-                    }}/"
-                    >{{ device.name }}
+                    }}/">{{ device.name }}
                   </a>
                 </p>
 

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -70,17 +70,18 @@
         </ol>
 
         <div id="releases">
+          {% for release in details.release_details.releases %}
           <div class="release box">
             <h3 class="enabled">
-              Ubuntu 16.04 LTS 64-bit
+              {{ release.name }}
             </h3>
 
             <p class="availability">Pre-installed by manufacturer</p>
 
             <h4 id="testing-details">Testing details</h4>
             <p>
-              This system was tested with 16.04 LTS, running the
-              4.4.0-36-generic kernel.
+              This system was tested with {{ release.version }}, running the
+              {{ release.kernel }} kernel.
             </p>
             <p></p>
             <h4>Certification notes</h4>
@@ -89,10 +90,11 @@
 
             <dl id="bios-list">
               <dt>BIOS</dt>
-              <dd>Dell: 0.5.3 (UEFI)</dd>
+              <dd>{{ release.bios }}</dd>
             </dl>
           </div>
         </div>
+        {% endfor %}
 
         <h2>Hardware summary</h2>
         <p>This system was tested with these key components:</p>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -41,7 +41,9 @@
         If there is an issue with the information for this system, please
         <a
           target="_blank"
-          href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the Dell ChengMing 3977 - phoenix KBL"
+          href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the {{
+            details.vendor
+          }} {{ details.name }}"
           >let us know</a
         >.
       </p>
@@ -133,267 +135,26 @@
 
         <table class="definitions">
           <tbody>
+            {% for category, devices in details.hardware_details.items() %}
             <tr>
-              <td class="title">Audio</td>
+              <td style="text-transform: capitalize;" class="title">
+                {{ category }}
+              </td>
               <td class="details">
-                <p>
-                  <a href="/catalog/component/pci/8086%3Aa170/"
-                    >Intel Sunrise Point-H HD Audio
-                  </a>
-                </p>
-
+                {% for device in devices %}
                 <p>
                   <a
-                    href="/catalog/component/sound/4103/sound%3ASunrisePoint-HHDAudio/"
-                    >Intel Sunrise Point-H HD Audio
+                    href="/catalog/component/{{ device.bus }}/{{
+                      device.identifier
+                    }}/"
+                    >{{ device.name }}
                   </a>
                 </p>
+
+                {% endfor %}
               </td>
             </tr>
-
-            <tr>
-              <td class="title">BIOS</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/dmi/4755/dmi%3A0.5.3/"
-                    >Dell 0.5.3
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Board</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/dmi/4755/dmi%3AUnknown/"
-                    >Dell Unknown
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Chassis</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/dmi/4755/dmi%3ADesktop/"
-                    >Dell Desktop
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Disk</td>
-              <td class="details">
-                <p>
-                  <a
-                    href="/catalog/component/scsi/4932/scsi%3AST500DM002-1SB10A/"
-                    >Aquantia Corp. ST500DM002-1SB10A
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Efi</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/dmi/86/dmi%3AEFIv2.40/"
-                    >American Megatrends Inc. EFI v2.40
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Mouse</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/usb/2024/046d%3Ac534/"
-                    >Logitech, Inc. Unifying Receiver
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Network</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/pci/10ec%3A8168/"
-                    >Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI
-                    Express Gigabit Ethernet Controller
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Processor</td>
-              <td class="details">
-                <p>
-                  <a
-                    href="/catalog/component/dmi/4103/dmi%3AIntel%28R%29Core%28TM%29i5-7500CPU%403.40GHz/"
-                    >Intel Intel(R) Core(TM) i5-7500 CPU @ 3.40GHz
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">System</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/dmi/4755/dmi%3AChengMing3977/"
-                    >Dell ChengMing 3977
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Usb</td>
-              <td class="details">
-                <p>
-                  <a href="/catalog/component/pci/8086%3Aa12f/"
-                    >Intel Sunrise Point-H USB 3.0 xHCI Controller
-                  </a>
-                </p>
-              </td>
-            </tr>
-
-            <tr>
-              <td class="title">Other</td>
-              <td class="details">
-                <p>
-                  <a
-                    href="/catalog/component/input/4932/input%3ADellWMIhotkeys/"
-                    >Aquantia Corp. Dell WMI hotkeys
-                  </a>
-                </p>
-
-                <p>
-                  <a
-                    href="/catalog/component/input/4932/input%3AHDAIntelPCHHDMI/DP%2Cpcm%3D3/"
-                    >Aquantia Corp. HDA Intel PCH HDMI/DP,pcm=3
-                  </a>
-                </p>
-
-                <p>
-                  <a
-                    href="/catalog/component/input/4932/input%3AHDAIntelPCHHDMI/DP%2Cpcm%3D7/"
-                    >Aquantia Corp. HDA Intel PCH HDMI/DP,pcm=7
-                  </a>
-                </p>
-
-                <p>
-                  <a
-                    href="/catalog/component/input/4932/input%3AHDAIntelPCHHDMI/DP%2Cpcm%3D8/"
-                    >Aquantia Corp. HDA Intel PCH HDMI/DP,pcm=8
-                  </a>
-                </p>
-
-                <p>
-                  <a
-                    href="/catalog/component/input/4932/input%3AHDAIntelPCHHeadphoneMic/"
-                    >Aquantia Corp. HDA Intel PCH Headphone Mic
-                  </a>
-                </p>
-
-                <p>
-                  <a
-                    href="/catalog/component/input/4932/input%3AHDAIntelPCHLineOut/"
-                    >Aquantia Corp. HDA Intel PCH Line Out
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/input/4932/input%3APowerButton/"
-                    >Aquantia Corp. Power Button
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/input/4932/input%3ASleepButton/"
-                    >Aquantia Corp. Sleep Button
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/input/4932/input%3AVideoBus/"
-                    >Aquantia Corp. Video Bus
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/104c%3A8240/"
-                    >Texas Instruments XIO2001 PCI Express-to-PCI Bridge
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/1fd4%3A1999/"
-                    >SUNIX Co., Ltd. Multiport serial controller
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/8086%3A1901/"
-                    >Intel Sky Lake PCIe Controller (x16)
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/8086%3Aa102/"
-                    >Intel Sunrise Point-H SATA controller [AHCI mode]
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/8086%3Aa115/"
-                    >Intel Sunrise Point-H PCI Express Root Port #6
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/8086%3Aa121/"
-                    >Intel Sunrise Point-H PMC
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/8086%3Aa123/"
-                    >Intel Sunrise Point-H SMBus
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/8086%3Aa131/"
-                    >Intel Sunrise Point-H Thermal subsystem
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/pci/8086%3Aa13a/"
-                    >Intel Sunrise Point-H CSME HECI #1
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/usb/4034/1d6b%3A0002/"
-                    >Linux Foundation 2.0 root hub
-                  </a>
-                </p>
-
-                <p>
-                  <a href="/catalog/component/usb/4034/1d6b%3A0003/"
-                    >Linux Foundation 3.0 root hub
-                  </a>
-                </p>
-              </td>
-            </tr>
+            {% endfor %}
           </tbody>
         </table>
       </div>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -1,8 +1,6 @@
 {% extends '_layout.html' %} {% block title%} Ubuntu Desktop certified hardware
 {% endblock %} {% block content %}
 
-{{ details.release_details }}
-
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
     <li>
@@ -13,8 +11,9 @@
     <li>&nbsp;›</li>
 
     <li>
-      <a href="https://certification.ubuntu.com/desktop/models/?category=Desktop&amp;category=Laptop&amp;vendors=Dell">Search
-        Results</a>
+      <a href="https://certification.ubuntu.com/desktop/models/?category=Desktop">
+        Search Results
+      </a>
     </li>
     <li>&nbsp;›</li>
 
@@ -25,8 +24,7 @@
 <div class="row row-hero no-border">
   <div class="container-inner title">
     <h1>
-      Ubuntu on {{ details.vendor
-      }}<span class="grey"> {{ details.name }}</span>
+      Ubuntu on {{ details.vendor }}<span class="grey"> {{ details.name }}</span>
     </h1>
   </div>
 
@@ -37,9 +35,10 @@
       <h4>Feedback</h4>
       <p>
         If there is an issue with the information for this system, please
-        <a target="_blank" href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the {{
-            details.vendor
-          }} {{ details.name }}">let us know</a>.
+        <a target="_blank"
+          href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the {{details.vendor}} {{ details.name }}">
+          let us know
+        </a>.
       </p>
     </div>
   </div>
@@ -107,9 +106,8 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  <a href="/catalog/component/{{ device.bus }}/{{
-                      device.identifier
-                    }}/">{{ device.name }}
+                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}/">
+                    {{ device.name }}
                   </a>
                   </a>
                 </p>
@@ -125,6 +123,7 @@
         <table class="definitions">
           <tbody>
             {% for category, devices in details.hardware_details.items() %}
+            {% if category != "other" %}
             <tr>
               <td style="text-transform: capitalize;" class="title">
                 {{ category }}
@@ -132,16 +131,31 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  <a href="/catalog/component/{{ device.bus }}/{{
-                      device.identifier
-                    }}/">{{ device.name }}
+                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}/">
+                    {{ device.name }}
                   </a>
                 </p>
 
                 {% endfor %}
               </td>
             </tr>
+            {% endif %}
             {% endfor %}
+            <tr>
+              <td style="text-transform: capitalize;" class="title">
+                other
+              </td>
+              <td class="details">
+                {% for device in details.hardware_details["other"] %}
+                <p>
+                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}/">
+                    {{ device.name }}
+                  </a>
+                </p>
+
+                {% endfor %}
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -1,0 +1,405 @@
+{% extends '_layout.html' %} {% block title%} Ubuntu Desktop certified hardware
+{% endblock %} {% block content %}
+
+{{ details }}
+
+<nav role="navigation" class="nav-secondary clearfix">
+  <ul class="breadcrumb">
+    <li>
+      <a href="/desktop/">
+        Ubuntu Desktop
+      </a>
+    </li>
+    <li>&nbsp;›</li>
+
+    <li>
+      <a
+        href="https://certification.ubuntu.com/desktop/models/?category=Desktop&amp;category=Laptop&amp;vendors=Dell"
+        >Search Results</a
+      >
+    </li>
+    <li>&nbsp;›</li>
+
+    <li class="third-level">Detail</li>
+  </ul>
+</nav>
+
+<div class="row row-hero no-border">
+  <div class="container-inner title">
+    <h1>
+      Ubuntu on {{ details.vendor
+      }}<span class="grey"> {{ details.name }}</span>
+    </h1>
+  </div>
+
+  <div class="three-col">
+    <form id="sidebar-search" action="" method="get" class="body-search"></form>
+
+    <div id="ubuntu-feedback">
+      <h4>Feedback</h4>
+      <p>
+        If there is an issue with the information for this system, please
+        <a
+          target="_blank"
+          href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the Dell ChengMing 3977 - phoenix KBL"
+          >let us know</a
+        >.
+      </p>
+    </div>
+  </div>
+
+  <div class="main">
+    <div class="nine-col  last-col device">
+      <div class="row row-hero" id="hardware-detail">
+        <p class="large">
+          The <strong>{{ details.vendor }} {{ details.name }}</strong> desktop
+          with the components described below has been awarded the status of
+          certified pre-install for Ubuntu.
+        </p>
+
+        <h3><strong>Please note that for pre-installed systems:</strong></h3>
+        <ol>
+          <li>
+            The system is available in some regions with a special image of
+            Ubuntu pre-installed by the manufacturer. It takes advantage of the
+            hardware features for this system and may include additional
+            software. You should check when buying the system whether this is an
+            option.
+          </li>
+          <li>
+            Standard images of Ubuntu may not work at all on the system or may
+            not work well, though Canonical and computer manufacturers will try
+            to certify the system with future standard releases of Ubuntu.
+          </li>
+        </ol>
+
+        <div id="releases">
+          <div class="release box">
+            <h3 class="enabled">
+              Ubuntu 16.04 LTS 64-bit
+            </h3>
+
+            <p class="availability">Pre-installed by manufacturer</p>
+
+            <h4 id="testing-details">Testing details</h4>
+            <p>
+              This system was tested with 16.04 LTS, running the
+              4.4.0-36-generic kernel.
+            </p>
+            <p></p>
+            <h4>Certification notes</h4>
+
+            <p>There are no notes for this release.</p>
+
+            <dl id="bios-list">
+              <dt>BIOS</dt>
+              <dd>Dell: 0.5.3 (UEFI)</dd>
+            </dl>
+          </div>
+        </div>
+
+        <h2>Hardware summary</h2>
+        <p>This system was tested with these key components:</p>
+
+        <table class="definitions">
+          <tbody>
+            <tr>
+              <td class="title">Processor</td>
+              <td class="details">
+                <p>
+                  <a
+                    href="/catalog/component/dmi/4103/dmi%3AIntel%28R%29Core%28TM%29i5-7500CPU%403.40GHz/"
+                    >Intel Intel(R) Core(TM) i5-7500 CPU @ 3.40GHz
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Ethernet</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/pci/10ec%3A8168/"
+                    >Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI
+                    Express Gigabit Ethernet Controller
+                  </a>
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>Hardware details</h2>
+
+        <table class="definitions">
+          <tbody>
+            <tr>
+              <td class="title">Audio</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/pci/8086%3Aa170/"
+                    >Intel Sunrise Point-H HD Audio
+                  </a>
+                </p>
+
+                <p>
+                  <a
+                    href="/catalog/component/sound/4103/sound%3ASunrisePoint-HHDAudio/"
+                    >Intel Sunrise Point-H HD Audio
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">BIOS</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/dmi/4755/dmi%3A0.5.3/"
+                    >Dell 0.5.3
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Board</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/dmi/4755/dmi%3AUnknown/"
+                    >Dell Unknown
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Chassis</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/dmi/4755/dmi%3ADesktop/"
+                    >Dell Desktop
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Disk</td>
+              <td class="details">
+                <p>
+                  <a
+                    href="/catalog/component/scsi/4932/scsi%3AST500DM002-1SB10A/"
+                    >Aquantia Corp. ST500DM002-1SB10A
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Efi</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/dmi/86/dmi%3AEFIv2.40/"
+                    >American Megatrends Inc. EFI v2.40
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Mouse</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/usb/2024/046d%3Ac534/"
+                    >Logitech, Inc. Unifying Receiver
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Network</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/pci/10ec%3A8168/"
+                    >Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI
+                    Express Gigabit Ethernet Controller
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Processor</td>
+              <td class="details">
+                <p>
+                  <a
+                    href="/catalog/component/dmi/4103/dmi%3AIntel%28R%29Core%28TM%29i5-7500CPU%403.40GHz/"
+                    >Intel Intel(R) Core(TM) i5-7500 CPU @ 3.40GHz
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">System</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/dmi/4755/dmi%3AChengMing3977/"
+                    >Dell ChengMing 3977
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Usb</td>
+              <td class="details">
+                <p>
+                  <a href="/catalog/component/pci/8086%3Aa12f/"
+                    >Intel Sunrise Point-H USB 3.0 xHCI Controller
+                  </a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="title">Other</td>
+              <td class="details">
+                <p>
+                  <a
+                    href="/catalog/component/input/4932/input%3ADellWMIhotkeys/"
+                    >Aquantia Corp. Dell WMI hotkeys
+                  </a>
+                </p>
+
+                <p>
+                  <a
+                    href="/catalog/component/input/4932/input%3AHDAIntelPCHHDMI/DP%2Cpcm%3D3/"
+                    >Aquantia Corp. HDA Intel PCH HDMI/DP,pcm=3
+                  </a>
+                </p>
+
+                <p>
+                  <a
+                    href="/catalog/component/input/4932/input%3AHDAIntelPCHHDMI/DP%2Cpcm%3D7/"
+                    >Aquantia Corp. HDA Intel PCH HDMI/DP,pcm=7
+                  </a>
+                </p>
+
+                <p>
+                  <a
+                    href="/catalog/component/input/4932/input%3AHDAIntelPCHHDMI/DP%2Cpcm%3D8/"
+                    >Aquantia Corp. HDA Intel PCH HDMI/DP,pcm=8
+                  </a>
+                </p>
+
+                <p>
+                  <a
+                    href="/catalog/component/input/4932/input%3AHDAIntelPCHHeadphoneMic/"
+                    >Aquantia Corp. HDA Intel PCH Headphone Mic
+                  </a>
+                </p>
+
+                <p>
+                  <a
+                    href="/catalog/component/input/4932/input%3AHDAIntelPCHLineOut/"
+                    >Aquantia Corp. HDA Intel PCH Line Out
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/input/4932/input%3APowerButton/"
+                    >Aquantia Corp. Power Button
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/input/4932/input%3ASleepButton/"
+                    >Aquantia Corp. Sleep Button
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/input/4932/input%3AVideoBus/"
+                    >Aquantia Corp. Video Bus
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/104c%3A8240/"
+                    >Texas Instruments XIO2001 PCI Express-to-PCI Bridge
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/1fd4%3A1999/"
+                    >SUNIX Co., Ltd. Multiport serial controller
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/8086%3A1901/"
+                    >Intel Sky Lake PCIe Controller (x16)
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/8086%3Aa102/"
+                    >Intel Sunrise Point-H SATA controller [AHCI mode]
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/8086%3Aa115/"
+                    >Intel Sunrise Point-H PCI Express Root Port #6
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/8086%3Aa121/"
+                    >Intel Sunrise Point-H PMC
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/8086%3Aa123/"
+                    >Intel Sunrise Point-H SMBus
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/8086%3Aa131/"
+                    >Intel Sunrise Point-H Thermal subsystem
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/pci/8086%3Aa13a/"
+                    >Intel Sunrise Point-H CSME HECI #1
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/usb/4034/1d6b%3A0002/"
+                    >Linux Foundation 2.0 root hub
+                  </a>
+                </p>
+
+                <p>
+                  <a href="/catalog/component/usb/4034/1d6b%3A0003/"
+                    >Linux Foundation 3.0 root hub
+                  </a>
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div></div>
+  </div>
+</div>
+
+{% endblock %}

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -59,4 +59,10 @@ def get_device_information_by_hardware_id(id):
         .get("objects")
     )
 
+    model_info["release_details"] = (
+        get(f"certifiedmodeldetails/?format=json&canonical_id={id}")
+        .json()
+        .get("objects")
+    )
+
     return model_info

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -42,3 +42,21 @@ def get_iot():
 
 def get_servers():
     return get_releases_by_vendor()
+
+
+def get_device_information_by_hardware_id(id):
+    model_info = (
+        get(f"certifiedmodels/?format=json&canonical_id={id}")
+        .json()
+        .get("objects")[0]
+    )
+    model_info["hardware_details"] = (
+        get(
+            "certifiedmodeldevices/"
+            f"?format=json&canonical_id={id}&limit=1000"
+        )
+        .json()
+        .get("objects")
+    )
+
+    return model_info

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -19,30 +19,33 @@ certification_blueprint = Blueprint(
 )
 
 
-@certification_blueprint.route("/hardware/<hardwareid>")
-def hardware(hardwareid):
-    modelinfo_data = get_device_information_by_hardware_id(hardwareid)
+@certification_blueprint.route("/hardware/<hardware_id>")
+def hardware(hardware_id):
+    modelinfo_data = get_device_information_by_hardware_id(hardware_id)
 
-    hardware_details = {"categories": {}}
+    hardware_details = {}
     for component in modelinfo_data.get("hardware_details"):
         category = component.get("category")
-        if category not in hardware_details.get("categories"):
-            hardware_details.get("categories")[category] = []
+        if category != "BIOS":
+            category = category.lower()
+        if category not in hardware_details:
+            hardware_details[category] = []
 
         hardware_info = {
-            "name": component.get("name"),
+            "name": f"{component.get('make')} {component.get('name')}",
             "bus": component.get("bus"),
             "identifier": component.get("identifier"),
         }
 
-        hardware_details.get("categories")[category].append(hardware_info)
+        hardware_details[category].append(hardware_info)
 
     details = {
-        "id": hardwareid,
+        "id": hardware_id,
         "name": modelinfo_data.get("model"),
         "vendor": modelinfo_data.get("make"),
         "major_release": modelinfo_data.get("major_release"),
         "hardware_details": hardware_details,
+        "release_details": modelinfo_data.get("release_details"),
     }
 
     return render_template("hardware.html", details=details)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -39,13 +39,39 @@ def hardware(hardware_id):
 
         hardware_details[category].append(hardware_info)
 
+    release_details = {"components": {}}
+    for release in modelinfo_data.get("release_details"):
+        for key, values in release.items():
+            if key in ["video", "processor", "network", "wireless"] and values:
+                # TODO: For each device => get the correct BUS and IDentifier
+                devices = []
+                for name in values:
+                    # Device cant be in releasedetails but not hardwaredetails.
+                    # Would be an API error, since its the same machine
+                    device = next(
+                        (
+                            x
+                            for x in hardware_details[key]
+                            if name in x["name"]
+                        ),
+                        None,
+                    )
+                    devices.append(device)
+
+                if key in release_details["components"]:
+                    release_details["components"][key] = (
+                        release_details["components"][key] + devices
+                    )
+                else:
+                    release_details["components"][key] = devices
+
     details = {
         "id": hardware_id,
         "name": modelinfo_data.get("model"),
         "vendor": modelinfo_data.get("make"),
         "major_release": modelinfo_data.get("major_release"),
         "hardware_details": hardware_details,
-        "release_details": modelinfo_data.get("release_details"),
+        "release_details": release_details,
     }
 
     return render_template("hardware.html", details=details)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -7,6 +7,7 @@ from webapp.api import (
     get_servers,
     get_iot,
     get_laptops,
+    get_device_information_by_hardware_id,
 )
 
 
@@ -16,6 +17,35 @@ certification_blueprint = Blueprint(
     template_folder="/templates",
     static_folder="/static",
 )
+
+
+@certification_blueprint.route("/hardware/<hardwareid>")
+def hardware(hardwareid):
+    modelinfo_data = get_device_information_by_hardware_id(hardwareid)
+
+    hardware_details = {"categories": {}}
+    for component in modelinfo_data.get("hardware_details"):
+        category = component.get("category")
+        if category not in hardware_details.get("categories"):
+            hardware_details.get("categories")[category] = []
+
+        hardware_info = {
+            "name": component.get("name"),
+            "bus": component.get("bus"),
+            "identifier": component.get("identifier"),
+        }
+
+        hardware_details.get("categories")[category].append(hardware_info)
+
+    details = {
+        "id": hardwareid,
+        "name": modelinfo_data.get("model"),
+        "vendor": modelinfo_data.get("make"),
+        "major_release": modelinfo_data.get("major_release"),
+        "hardware_details": hardware_details,
+    }
+
+    return render_template("hardware.html", details=details)
 
 
 @certification_blueprint.route("/desktop")

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -39,11 +39,24 @@ def hardware(hardware_id):
 
         hardware_details[category].append(hardware_info)
 
-    release_details = {"components": {}}
+    release_details = {"components": {}, "releases": []}
     for release in modelinfo_data.get("release_details"):
+        release_version = release["certified_release"]
+        release_name = (
+            "Ubuntu "
+            f"{release_version} "
+            f"{ '64 Bit' if release['architecture'] == 'amd64' else '32 Bit'}"
+        )
+        release_info = {
+            "name": release_name,
+            "kernel": release["kernel_version"],
+            "bios": release["bios"],
+            "release_version": release_version,
+        }
+        release_details["releases"].append(release_info)
+
         for key, values in release.items():
             if key in ["video", "processor", "network", "wireless"] and values:
-                # TODO: For each device => get the correct BUS and IDentifier
                 devices = []
                 for name in values:
                     # Device cant be in releasedetails but not hardwaredetails.


### PR DESCRIPTION
# Done
Fixes https://github.com/canonical-web-and-design/base-squad/issues/624

# QA
- `./run`
- head to e.g. http://localhost:8034/hardware/201612-25299 and compare with http://certification.ubuntu.com/hardware/201612-25299
- Should also work for any other hardware ID