### PR TITLE
Error pages, titles and remove ordering

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,1 +1,15 @@
-404
+{% extends '_layout.html' %}
+
+{% block title%}404: Page not found{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="eight-col">
+    <h1>404: Page not found</h1>
+    <p class="p-heading--four">Sorry, we couldn’t find that page.</p>
+  </div>
+  <div class="four-col last-col">
+    <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg?w=200" alt="Error owl" width="200">
+  </div>
+</div>
+{% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,1 +1,15 @@
-500
+{% extends '_layout.html' %}
+
+{% block title%}500: Server error{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="eight-col">
+    <h1>500: Server error</h1>
+    <p class="p-heading--four">Something&rsquo;s gone wrong.</p>
+  </div>
+  <div class="four-col last-col">
+    <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg?w=200" alt="Error owl" width="200">
+  </div>
+</div>
+{% endblock %}

--- a/templates/components/details.html
+++ b/templates/components/details.html
@@ -1,6 +1,6 @@
 {% extends '_layout.html' %}
 
-{% block title%}Ubuntu Server certified hardware{% endblock %}
+{% block title%}Component Device Details{% endblock %}
 
 {% block content %}
 <div class="row row-hero no-border">

--- a/templates/components/details.html
+++ b/templates/components/details.html
@@ -82,7 +82,7 @@
             {% for machine in machines %}
               <tr>
                 <td>
-                  <a href="/hardware/{{ machine.canonical_id }}/">{{ machine.canonical_id }}</a> {{ machine.make }} {{ machine.model }}</td>
+                  <a href="/hardware/{{ machine.canonical_id }}">{{ machine.canonical_id }}</a> {{ machine.make }} {{ machine.model }}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/templates/components/index.html
+++ b/templates/components/index.html
@@ -1,6 +1,6 @@
 {% extends '_layout.html' %}
 
-{% block title%}Ubuntu Server certified hardware{% endblock %}
+{% block title%}Component Devices{% endblock %}
 
 {% block content %}
 <div class="row row-hero no-border">

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -78,7 +78,7 @@
         <tr>
           <td>
             <a
-              href="/desktop/models/?category=Desktop&amp;category=Laptop&amp;vendors={{
+              href="/desktop/modelscategory=Desktop&amp;category=Laptop&amp;vendors={{
                 vendor.make
               }}"
               >{{ vendor.make }}</a
@@ -87,7 +87,7 @@
           <td>
             {% if vendor.desktops == "0" %} - {% else %}
             <a
-              href="/desktop/models/?category=Desktop&amp;vendors={{
+              href="/desktop/models?category=Desktop&amp;vendors={{
                 vendor.make
               }}"
             >
@@ -98,7 +98,7 @@
           <td>
             {% if vendor.laptops == "0" %} - {% else %}
             <a
-              href="/desktop/models/?category=Laptop&amp;vendors={{
+              href="/desktop/models?category=Laptop&amp;vendors={{
                 vendor.make
               }}"
             >
@@ -127,7 +127,7 @@
         <tr>
           <td>
             <a
-              href="/desktop/models/?release={{
+              href="/desktop/models?release={{
                 release.release
               }}&amp;category=Desktop&amp;category=Laptop"
               >{{ release.release }}</a
@@ -136,7 +136,7 @@
           <td>
             {% if release.desktops== "0" %} - {% else %}
             <a
-              href="/desktop/models/?release={{
+              href="/desktop/models?release={{
                 release.release
               }}&amp;category=Desktop"
             >
@@ -147,7 +147,7 @@
           <td>
             {% if release.laptops == "0" %} - {% else %}
             <a
-              href="/desktop/models/?release={{
+              href="/desktop/models?release={{
                 release.release
               }}&amp;category=Laptop"
             >

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -1,6 +1,8 @@
-{% extends '_layout.html' %} {% block title%} Ubuntu Desktop certified hardware
-{% endblock %} {% block content %}
+{% extends '_layout.html' %}
 
+{% block title%}Ubuntu Desktop certified hardware{% endblock %}
+
+{% block content %}
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
     <li class="active">

--- a/templates/desktop/models.html
+++ b/templates/desktop/models.html
@@ -6,7 +6,7 @@
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
     <li>
-      <a href="/desktop/">
+      <a href="/desktop">
         Ubuntu Desktop
       </a>
     </li>
@@ -124,7 +124,7 @@
           <li class="model enabled">
             <p>
               {{ model.make }}
-              <a href="/hardware/{{ model.canonical_id }}/">{{ model.model }}</a> {{ model.category }}
+              <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a> {{ model.category }}
             </p>
           </li>
           {% endfor %}

--- a/templates/desktop/models.html
+++ b/templates/desktop/models.html
@@ -1,6 +1,6 @@
 {% extends '_layout.html' %}
 
-{% block title%}Ubuntu Server certified hardware{% endblock %}
+{% block title%}Ubuntu Desktop certified hardware{% endblock %}
 
 {% block content %}
 <nav role="navigation" class="nav-secondary clearfix">

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -6,14 +6,14 @@
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
     <li>
-      <a href="/desktop/">
+      <a href="/desktop">
         Ubuntu Desktop
       </a>
     </li>
     <li>&nbsp;›</li>
 
     <li>
-      <a href="https://certification.ubuntu.com/desktop/models/?category=Desktop">
+      <a href="/desktop/models?category=Desktop">
         Search Results
       </a>
     </li>
@@ -110,7 +110,7 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}/">
+                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}">
                     {{ device.name }}
                   </a>
                   </a>
@@ -135,7 +135,7 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}/">
+                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}">
                     {{ device.name }}
                   </a>
                 </p>
@@ -152,7 +152,7 @@
               <td class="details">
                 {% for device in hardware_details["other"] %}
                 <p>
-                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}/">
+                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}">
                     {{ device.name }}
                   </a>
                 </p>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -1,6 +1,8 @@
-{% extends '_layout.html' %} {% block title%} Ubuntu Desktop certified hardware
-{% endblock %} {% block content %}
+{% extends '_layout.html' %}
 
+{% block title %}Ubuntu on {{ vendor }}<span class="grey"> {{ name }}{% endblock %}
+
+{% block content %}
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
     <li>

--- a/templates/iot/index.html
+++ b/templates/iot/index.html
@@ -62,7 +62,7 @@ endblock %} {% block content %}
         <tr>
           <td>
             <a
-              href="/iot/models/?category=Ubuntu Core&amp;vendors={{
+              href="/iot/models?category=Ubuntu Core&amp;vendors={{
                 vendor.make
               }}"
               >{{ vendor.make }}</a
@@ -70,7 +70,7 @@ endblock %} {% block content %}
           </td>
           <td>
             <a
-              href="/iot/models/?category=Ubuntu Core&amp;vendors={{
+              href="/iot/models?category=Ubuntu Core&amp;vendors={{
                 vendor.make
               }}"
               >{{ vendor.smart_core }}</a
@@ -96,7 +96,7 @@ endblock %} {% block content %}
         <tr>
           <td>
             <a
-              href="/iot/models/?release={{
+              href="/iot/models?release={{
                 release.release
               }}&amp;category=Ubuntu Core"
               >{{ release.release }}</a
@@ -104,7 +104,7 @@ endblock %} {% block content %}
           </td>
           <td>
             <a
-              href="/iot/models/?release={{
+              href="/iot/models?release={{
                 release.release
               }}&amp;category=Ubuntu Core"
               >{{ release.smart_core }}</a

--- a/templates/iot/models.html
+++ b/templates/iot/models.html
@@ -6,7 +6,7 @@
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
     <li>
-      <a href="/iot/">
+      <a href="/iot">
         Ubuntu IoT
       </a>
     </li>
@@ -113,7 +113,7 @@
           <li class="model enabled">
             <p>
               {{ model.make }}
-              <a href="/hardware/{{ model.canonical_id }}/">{{ model.model }}</a> {{ model.category }}
+              <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a> {{ model.category }}
             </p>
           </li>
           {% endfor %}

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -1,6 +1,8 @@
-{% extends '_layout.html' %} {% block title%} Ubuntu Server certified hardware
-{% endblock %} {% block content %}
+{% extends '_layout.html' %}
 
+{% block title%} Ubuntu Server certified hardware{% endblock %}
+
+{% block content %}
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
     <li class="active">

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -36,7 +36,7 @@
           {% for release in releases %}
           <th scope="col">
             <a
-              href="/server/models/?release={{ release }}&amp;category=Server"
+              href="/server/models?release={{ release }}&amp;category=Server"
               >{{ release }}</a
             >
           </th>
@@ -47,7 +47,7 @@
         {% for vendor in vendors %}
         <tr>
           <td>
-            <a href="/server/models/?vendors={{ vendor['vendor'] }}">{{
+            <a href="/server/models?vendors={{ vendor['vendor'] }}">{{
               vendor["vendor"]
             }}</a>
           </td>
@@ -55,7 +55,7 @@
           <td>
             {% if not vendor[release] %} - {% else %}
             <a
-              href="/server/models/?release={{ release }}&amp;vendors={{
+              href="/server/models?release={{ release }}&amp;vendors={{
                 vendor['vendor']
               }}
               "

--- a/templates/server/models.html
+++ b/templates/server/models.html
@@ -6,7 +6,7 @@
 <nav role="navigation" class="nav-secondary clearfix">
     <ul class="breadcrumb">
         <li>
-            <a href="/server/">
+            <a href="/server">
                 Ubuntu Server
             </a>
         </li>
@@ -96,7 +96,7 @@
                     <li class="model enabled">
                         <p>
                             {{ model.make }}
-                            <a href="/hardware/{{ model.canonical_id }}/">{{ model.model }}</a> {{ model.category }}
+                            <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a> {{ model.category }}
                         </p>
                     </li>
                     {% endfor %}

--- a/templates/server/models.html
+++ b/templates/server/models.html
@@ -1,5 +1,8 @@
-{% extends '_layout.html' %} {% block title%} Ubuntu Server certified hardware
-{% endblock %} {% block content %}
+{% extends '_layout.html' %}
+
+{% block title%}Ubuntu Server certified hardware{% endblock %}
+
+{% block content %}
 <nav role="navigation" class="nav-secondary clearfix">
     <ul class="breadcrumb">
         <li>

--- a/templates/soc/index.html
+++ b/templates/soc/index.html
@@ -54,12 +54,12 @@
         {% for vendor in vendors %}
         <tr>
           <td>
-            <a href="/soc/models/?vendors={{ vendor.make }}">{{
+            <a href="/soc/models?vendors={{ vendor.make }}">{{
               vendor.make
             }}</a>
           </td>
           <td>
-            <a href="/soc/models/?vendors={{ vendor.make }}">{{
+            <a href="/soc/models?vendors={{ vendor.make }}">{{
               vendor.soc
             }}</a>
           </td>
@@ -82,12 +82,12 @@
         {% for release in releases %}
         <tr>
           <td>
-            <a href="/soc/models/?release={{ release.release }}">{{
+            <a href="/soc/models?release={{ release.release }}">{{
               release.release
             }}</a>
           </td>
           <td>
-            <a href="/soc/models/?release={{ release.release }}">{{
+            <a href="/soc/models?release={{ release.release }}">{{
               release.soc
             }}</a>
           </td>

--- a/templates/soc/index.html
+++ b/templates/soc/index.html
@@ -1,5 +1,8 @@
-{% extends '_layout.html' %} {% block title%} Ubuntu Server certified hardware
-{% endblock %} {% block content %}
+{% extends '_layout.html' %}
+
+{% block title%}Ubuntu System on a Chip certified hardware{% endblock %}
+
+{% block content %}
 <nav role="navigation" class="nav-secondary clearfix">
   <ul class="breadcrumb">
     <li class="active">

--- a/templates/soc/models.html
+++ b/templates/soc/models.html
@@ -6,7 +6,7 @@
 <nav role="navigation" class="nav-secondary clearfix">
     <ul class="breadcrumb">
         <li>
-            <a href="/soc/">
+            <a href="/soc">
                 Ubuntu SoC
             </a>
         </li>
@@ -97,7 +97,7 @@
                     <li class="model enabled">
                         <p>
                             {{ model.make }}
-                            <a href="/hardware/{{ model.canonical_id }}/">{{ model.model }}</a> {{ model.category }}
+                            <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a> {{ model.category }}
                         </p>
                     </li>
                     {% endfor %}

--- a/templates/soc/models.html
+++ b/templates/soc/models.html
@@ -1,6 +1,6 @@
 {% extends '_layout.html' %}
 
-{% block title%} Ubuntu Server SoC certified hardware{% endblock %}
+{% block title%}Ubuntu Server SoC certified hardware{% endblock %}
 
 {% block content %}
 <nav role="navigation" class="nav-secondary clearfix">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -146,7 +146,6 @@ def desktop_models():
         make__regex=query,
         # We should use query instead of make__regex as soon as it's ready
         # query=query,
-        order_by="make",
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]
@@ -219,7 +218,6 @@ def server_models():
         make__regex=query,
         # We should use query instead of make__regex as soon as it's ready
         # query=query,
-        order_by="make",
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]
@@ -288,7 +286,6 @@ def iot_models():
         make__regex=query,
         # We should use query instead of make__regex as soon as it's ready
         # query=query,
-        order_by="make",
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]
@@ -351,7 +348,6 @@ def soc_models():
         make__regex=query,
         # We should use query instead of make__regex as soon as it's ready
         # query=query,
-        order_by="make",
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]


### PR DESCRIPTION
- Fixes up titles
- Added error pages
- Remove any `order_by` logic, as the API should very soon return results in the desired order itself.

QA
--

`./run`, go to http://0.0.0.0:8034/idontexist and see the 404 page.

Seeing the 500 pages is a bit harder. Why not throw a random undefined variable call into a view in `app.py` or something?