### PR TITLE
Remove links from /hardware pages

### DIFF
--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -145,12 +145,13 @@
             </tr>
             {% endif %}
             {% endfor %}
+            {% if "Other" in hardware_details and hardware_details["Other"] %}
             <tr>
               <td class="title">
                 Other
               </td>
               <td class="details">
-                {% for device in hardware_details["other"] %}
+                {% for device in hardware_details["Other"] %}
                 <p>
                   <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}">
                     {{ device.name }}
@@ -160,6 +161,7 @@
                 {% endfor %}
               </td>
             </tr>
+            {% endif %}
           </tbody>
         </table>
       </div>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -110,10 +110,8 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}">
-                    {{ device.name }}
-                  </a>
-                  </a>
+                  {{ device.name }}
+                  {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}){% endif %}
                 </p>
                 {% endfor %}
               </td>
@@ -135,9 +133,8 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}">
-                    {{ device.name }}
-                  </a>
+                  {{ device.name }}
+                  {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}){% endif %}
                 </p>
 
                 {% endfor %}
@@ -153,9 +150,8 @@
               <td class="details">
                 {% for device in hardware_details["Other"] %}
                 <p>
-                  <a href="/catalog/component/{{ device.bus }}/{{ device.identifier }}">
-                    {{ device.name }}
-                  </a>
+                  {{ device.name }}
+                  {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}){% endif %}
                 </p>
 
                 {% endfor %}


### PR DESCRIPTION
And add identifiers to USB and PCI bus types.

QA
--

`./run`, go to e.g. http://0.0.0.0:8034/hardware/201811-26620, and maybe some other hardware pages. Check you see identifiers next to many of the devices. Check there are no longer dead links on the page.