### PR TITLE
Fix search and vendors with commas

### DIFF
--- a/templates/components/index.html
+++ b/templates/components/index.html
@@ -11,14 +11,14 @@
     <form id="sidebar-search" method="get" class="body-search">
       <fieldset>
         <div id="search">
-          <input id="id_query" type="text" name="query" value="" placeholder="search" maxlength="200" />
+          <input id="id_query" type="text" name="query" value="{{ query }}" placeholder="search" maxlength="200" />
         </div>
         <div id="filter">
           <ul>
             {% for vendor in all_vendors %}
               <li>
-                <input type="checkbox" id="vendor" name="vendor" value="{{ vendor }}" {{ "checked" if vendor in vendors }}>
-                <label for="vendor">{{ vendor }}</label>
+                <input type="checkbox" id="vendor_{{ loop.index }}" name="vendor" value="{{ vendor }}" {{ "checked" if vendor in vendors }}>
+                <label for="vendor_{{ loop.index }}">{{ vendor }}</label>
               </li>
             {% endfor %}
           </ul>

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -77,33 +77,16 @@
         {% for vendor in vendors %}
         <tr>
           <td>
-            <a
-              href="/desktop/modelscategory=Desktop&amp;category=Laptop&amp;vendors={{
-                vendor.make
-              }}"
-              >{{ vendor.make }}</a
-            >
+            <a href="/desktop/models?vendors={{vendor.make}}">{{ vendor.make }}</a>
           </td>
           <td>
             {% if vendor.desktops == "0" %} - {% else %}
-            <a
-              href="/desktop/models?category=Desktop&amp;vendors={{
-                vendor.make
-              }}"
-            >
-              {{ vendor.desktops }}
-            </a>
+            <a href="/desktop/models?category=Desktop&amp;vendors={{vendor.make}}">{{ vendor.desktops }}</a>
             {% endif %}
           </td>
           <td>
             {% if vendor.laptops == "0" %} - {% else %}
-            <a
-              href="/desktop/models?category=Laptop&amp;vendors={{
-                vendor.make
-              }}"
-            >
-              {{ vendor.laptops }}
-            </a>
+            <a href="/desktop/models?category=Laptop&amp;vendors={{vendor.make}}">{{ vendor.laptops }}</a>
             {% endif %}
           </td>
         </tr>
@@ -126,33 +109,16 @@
         {% for release in releases %}
         <tr>
           <td>
-            <a
-              href="/desktop/models?release={{
-                release.release
-              }}&amp;category=Desktop&amp;category=Laptop"
-              >{{ release.release }}</a
-            >
+            <a href="/desktop/models?release={{release.release}}">{{ release.release }}</a>
           </td>
           <td>
             {% if release.desktops== "0" %} - {% else %}
-            <a
-              href="/desktop/models?release={{
-                release.release
-              }}&amp;category=Desktop"
-            >
-              {{ release.desktops }}
-            </a>
+            <a href="/desktop/models?release={{release.release}}&amp;category=Desktop">{{ release.desktops }}</a>
             {% endif %}
           </td>
           <td>
             {% if release.laptops == "0" %} - {% else %}
-            <a
-              href="/desktop/models?release={{
-                release.release
-              }}&amp;category=Laptop"
-            >
-              {{ release.laptops }}
-            </a>
+            <a href="/desktop/models?release={{release.release}}&amp;category=Laptop">{{ release.laptops }}</a>
             {% endif %}
           </td>
         </tr>

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -56,10 +56,9 @@ class CertificationAPI:
         canonical_id=None,
         canonical_id__in=None,
         major_release__in=None,
-        make__in=None,
+        vendor=None,
+        query=None,
         category__in=None,
-        model__regex=None,
-        make__regex=None,
         order_by=None,
     ):
         response = self._get(
@@ -69,13 +68,12 @@ class CertificationAPI:
                 "offset": offset,
                 "level": level,
                 "major_release__in": major_release__in,
-                "make__in": make__in,
+                "vendor": vendor,
+                "query": query,
                 "canonical_id": canonical_id,
                 "canonical_id__in": canonical_id__in,
                 "category": category,
                 "category__in": category__in,
-                "model__regex": model__regex,
-                "make__regex": make__regex,
                 "order_by": order_by,
             },
         )
@@ -126,8 +124,8 @@ class CertificationAPI:
         offset=None,
         id=None,
         canonical_id=None,
-        vendor_name__in=None,
-        model__regex=None,
+        query=None,
+        make=None,
     ):
         return self._get(
             "componentsummaries",
@@ -136,8 +134,8 @@ class CertificationAPI:
                 "offset": offset,
                 "id": id,
                 "canonical_id": canonical_id,
-                "vendor_name__in": vendor_name__in,
-                "model__regex": model__regex,
+                "query": query,
+                "make": make,
             },
         ).json()
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -144,10 +144,8 @@ def desktop_models():
         level=level,
         category__in=",".join(categories),
         major_release__in=",".join(releases) if releases else None,
-        make__in=",".join(vendors) if vendors else None,
-        make__regex=query,
-        # We should use query instead of make__regex as soon as it's ready
-        # query=query,
+        vendor=vendors,
+        query=query,
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]
@@ -216,10 +214,8 @@ def server_models():
     models_response = api.certifiedmodels(
         category="Server",
         major_release__in=",".join(releases) if releases else None,
-        make__in=",".join(vendors) if vendors else None,
-        make__regex=query,
-        # We should use query instead of make__regex as soon as it's ready
-        # query=query,
+        vendor=vendors,
+        query=query,
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]
@@ -284,10 +280,8 @@ def iot_models():
         level=level,
         category="Ubuntu Core",
         major_release__in=",".join(releases) if releases else None,
-        make__in=",".join(vendors) if vendors else None,
-        make__regex=query,
-        # We should use query instead of make__regex as soon as it's ready
-        # query=query,
+        vendor=vendors,
+        query=query,
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]
@@ -346,10 +340,8 @@ def soc_models():
     models_response = api.certifiedmodels(
         category="Server SoC",
         major_release__in=",".join(releases) if releases else None,
-        make__in=",".join(vendors) if vendors else None,
-        make__regex=query,
-        # We should use query instead of make__regex as soon as it's ready
-        # query=query,
+        vendor=vendors,
+        query=query,
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]
@@ -395,11 +387,7 @@ def components():
     vendors = flask.request.args.getlist("vendor")
 
     components_response = api.componentsummaries(
-        vendor_name__in=",".join(vendors) if vendors else None,
-        # We should use query instead of make__regex as soon as it's ready
-        # query=query,
-        model__regex=query,
-        offset=(int(page) - 1) * 20,
+        make=vendors, query=query, offset=(int(page) - 1) * 20
     )
     components = components_response["objects"]
     total = components_response["meta"]["total_count"]


### PR DESCRIPTION
Use the new `query` and `vendor=x&vendor=y`features in the API (thanks @codersquid) to fix the comma in vendor names problem, and the searcing problem.

QA
--

`./run`

- [ ] Go to e.g. http://0.0.0.0:8034/soc/models?vendors=Huawei+Technologies+Co.%2C+Ltd., check you see one result.
- [ ] Go to e.g. http://0.0.0.0:8034/server/models?query=&vendors=Cavium%2C+Inc.&vendors=Huawei+Technologies+Co.%2C+Ltd.&vendors=New+H3C+Technologies+Co.%2C+Ltd, check you see a bunch of results
- [ ] Check you can search both vendor names and product names, e.g. http://0.0.0.0:8034/desktop/models?query=thinkpad and http://0.0.0.0:8034/desktop/models?query=lenovo
- [ ] Check also the components section - e.g.: http://0.0.0.0:8034/components?query=amd, http://0.0.0.0:8034/components?query=baffin, http://0.0.0.0:8034/components?query=&vendor=Lenovo&vendor=nVidia