### PR TITLE
Multiple model names in /hardware, fix architecture

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ Flask==1.1.1
 python-frontmatter==0.4.5
 mistune==0.8.4
 bleach==3.1.0
-talisker[gunicorn]==0.15.0
+talisker[gunicorn,prometheus]==0.15.0
 

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -10,6 +10,10 @@
       type="image/x-icon"
     />
 
+    <meta charset="UTF-8" />
+    <meta name="description" content="Hardware that have been certified for use with Ubuntu." />
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -79,12 +79,8 @@
                 {{ release.name }}
               </h3>
 
-              {% if category != "Ubuntu Core" %}
-                {% if release.level == "Certified" %}
-                <p class="availability">Available from ubuntu.com</p>
-                {% elif release.level == "Enabled" %}
+              {% if category != "Ubuntu Core" and release.level == "Enabled" %}
                 <p class="availability">Pre-installed by manufacturer</p>
-                {% endif %}
               {% endif %}
 
               <h4 id="testing-details">Testing details</h4>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -72,32 +72,32 @@
 
         <div id="releases">
           {% for release in release_details.releases %}
-          <div class="release box">
-            <h3 class="enabled">
-              {{ release.name }}
-            </h3>
+            <div class="release box">
+              <h3 class="enabled">
+                {{ release.name }}
+              </h3>
 
-            <p class="availability">Pre-installed by manufacturer</p>
+              <p class="availability">Pre-installed by manufacturer</p>
 
-            <h4 id="testing-details">Testing details</h4>
-            <p>
-              This system was tested with {{ release.version }}, running the
-              {{ release.kernel }} kernel.
-            </p>
-            <p></p>
-            <h4>Certification notes</h4>
+              <h4 id="testing-details">Testing details</h4>
+              <p>
+                This system was tested with {{ release.version }}, running the
+                {{ release.kernel }} kernel.
+              </p>
+              <p></p>
+              <h4>Certification notes</h4>
 
-            <p>There are no notes for this release.</p>
+              <p>There are no notes for this release.</p>
 
-            {% if release.bios %}
-            <dl id="bios-list">
-              <dt>BIOS</dt>
-              <dd>{{ release.bios }}</dd>
-            </dl>
-            {% endif %}
-          </div>
+              {% if release.bios %}
+                <dl id="bios-list">
+                  <dt>BIOS</dt>
+                  <dd>{{ release.bios }}</dd>
+                </dl>
+              {% endif %}
+            </div>
+          {% endfor %}
         </div>
-        {% endfor %}
 
         <h2>Hardware summary</h2>
         <p>This system was tested with these key components:</p>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -77,7 +77,13 @@
                 {{ release.name }}
               </h3>
 
-              <p class="availability">Pre-installed by manufacturer</p>
+              {% if category != "Ubuntu Core" %}
+                {% if release.level == "Certified" %}
+                <p class="availability">Available from ubuntu.com</p>
+                {% elif release.level == "Enabled" %}
+                <p class="availability">Pre-installed by manufacturer</p>
+                {% endif %}
+              {% endif %}
 
               <h4 id="testing-details">Testing details</h4>
               <p>

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -49,26 +49,28 @@
     <div class="nine-col  last-col device">
       <div class="row row-hero" id="hardware-detail">
         <p class="large">
-          The <strong>{{ vendor }} {{ name }}</strong> desktop
+          The <strong>{{ vendor }} {{ name }}</strong> {{ category.lower() }}
           with the components described below has been awarded the status of
-          certified pre-install for Ubuntu.
+          certified {% if has_enabled_releases %}pre-install {% endif %}for Ubuntu.
         </p>
 
-        <h3><strong>Please note that for pre-installed systems:</strong></h3>
-        <ol>
-          <li>
-            The system is available in some regions with a special image of
-            Ubuntu pre-installed by the manufacturer. It takes advantage of the
-            hardware features for this system and may include additional
-            software. You should check when buying the system whether this is an
-            option.
-          </li>
-          <li>
-            Standard images of Ubuntu may not work at all on the system or may
-            not work well, though Canonical and computer manufacturers will try
-            to certify the system with future standard releases of Ubuntu.
-          </li>
-        </ol>
+        {% if has_enabled_releases %}
+          <h3><strong>Please note that for pre-installed systems:</strong></h3>
+          <ol>
+            <li>
+              The system is available in some regions with a special image of
+              Ubuntu pre-installed by the manufacturer. It takes advantage of the
+              hardware features for this system and may include additional
+              software. You should check when buying the system whether this is an
+              option.
+            </li>
+            <li>
+              Standard images of Ubuntu may not work at all on the system or may
+              not work well, though Canonical and computer manufacturers will try
+              to certify the system with future standard releases of Ubuntu.
+            </li>
+          </ol>
+        {% endif %}
 
         <div id="releases">
           {% for release in release_details.releases %}

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -1,6 +1,6 @@
 {% extends '_layout.html' %}
 
-{% block title %}Ubuntu on {{ vendor }}<span class="grey"> {{ name }}{% endblock %}
+{% block title %}Ubuntu on {{ vendor }} {{ name }}{% endblock %}
 
 {% block content %}
 <nav role="navigation" class="nav-secondary clearfix">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -22,7 +22,7 @@ app = FlaskBase(
 
 api = CertificationAPI(
     base_url="https://certification.canonical.com/api/v1",
-    session=CachedSession(),
+    session=CachedSession(timeout=5),
 )
 
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -34,6 +34,10 @@ def index():
 @app.route("/hardware/<canonical_id>")
 def hardware(canonical_id):
     models = api.certifiedmodels(canonical_id=canonical_id)["objects"]
+
+    if not models:
+        flask.abort(404)
+
     model_devices = api.certifiedmodeldevices(
         canonical_id=canonical_id, limit="0"
     )["objects"]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -33,9 +33,7 @@ def index():
 
 @app.route("/hardware/<canonical_id>")
 def hardware(canonical_id):
-    model_info = api.certifiedmodels(canonical_id=canonical_id, limit=1)[
-        "objects"
-    ][0]
+    models = api.certifiedmodels(canonical_id=canonical_id)["objects"]
     model_devices = api.certifiedmodeldevices(
         canonical_id=canonical_id, limit="0"
     )["objects"]
@@ -65,11 +63,10 @@ def hardware(canonical_id):
 
     for model_release in model_releases:
         ubuntu_version = model_release["certified_release"]
-        arch = ""
-        if model_release["architecture"] == "amd64":
+        arch = model_release["architecture"]
+
+        if arch == "amd64":
             arch = "64 Bit"
-        else:
-            arch = "32 Bit"
 
         release_info = {
             "name": f"Ubuntu {ubuntu_version} {arch}",
@@ -92,12 +89,15 @@ def hardware(canonical_id):
 
                 release_details["components"][device_category] = devices
 
+    # Build model name
+    model_names = [model["model"] for model in models]
+
     return flask.render_template(
         "hardware.html",
         canonical_id=canonical_id,
-        name=model_info.get("model"),
-        vendor=model_info.get("make"),
-        major_release=model_info.get("major_release"),
+        name=", ".join(model_names),
+        vendor=models[0]["make"],
+        major_release=models[0]["major_release"],
         hardware_details=hardware_details,
         release_details=release_details,
         # Only show the first 5 components

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -60,6 +60,7 @@ def hardware(canonical_id):
         hardware_details[category].append(device_info)
 
     release_details = {"components": {}, "releases": []}
+    has_enabled_releases = False
 
     for model_release in model_releases:
         ubuntu_version = model_release["certified_release"]
@@ -75,6 +76,10 @@ def hardware(canonical_id):
             "level": model_release["level"],
             "version": ubuntu_version,
         }
+
+        if release_info["level"] == "Enabled":
+            has_enabled_releases = True
+
         release_details["releases"].append(release_info)
 
         for device_category, devices in model_release.items():
@@ -102,6 +107,7 @@ def hardware(canonical_id):
         major_release=models[0]["major_release"],
         hardware_details=hardware_details,
         release_details=release_details,
+        has_enabled_releases=has_enabled_releases,
         # Only show the first 5 components
         components=api.componentsummaries(canonical_id=canonical_id)[
             "objects"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -72,6 +72,7 @@ def hardware(canonical_id):
             "name": f"Ubuntu {ubuntu_version} {arch}",
             "kernel": model_release["kernel_version"],
             "bios": model_release["bios"],
+            "level": model_release["level"],
             "version": ubuntu_version,
         }
         release_details["releases"].append(release_info)
@@ -96,6 +97,7 @@ def hardware(canonical_id):
         "hardware.html",
         canonical_id=canonical_id,
         name=", ".join(model_names),
+        category=models[0]["category"],
         vendor=models[0]["make"],
         major_release=models[0]["major_release"],
         hardware_details=hardware_details,


### PR DESCRIPTION
QA
--

`./run`

Check https://certification-ubuntu-com-canonical-web-and-design-pr-30.run.demo.haus/hardware/201806-26281 roughly matches https://certification.ubuntu.com/hardware/201806-26281/ (without the "Download" buttons):

- [ ] All model names in heading
- [ ] Mentions "s390x"

Maybe also try other pages on https://certification-ubuntu-com-canonical-web-and-design-pr-30.run.demo.haus/