### PR TITLE
Show appropriate ubuntu.com/download links

### DIFF
--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -79,9 +79,16 @@
                 {{ release.name }}
               </h3>
 
-              {% if category != "Ubuntu Core" and release.level == "Enabled" %}
+              {% if release.level == "Enabled" %}
                 <p class="availability">Pre-installed by manufacturer</p>
+              {% else %}
+                <p class="availability">Available from ubuntu.com</p>
               {% endif %}
+
+              {% if release.download_url %}
+              <p><a href="{{ release.download_url }}" id="download-url" class="button--primary link-cta-ubuntu cta-large">Download</a></p>
+              {% endif %}
+
 
               <h4 id="testing-details">Testing details</h4>
               <p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -8,7 +8,7 @@ from canonicalwebteam.http import CachedSession
 
 # Local
 from webapp.api import CertificationAPI
-from webapp.helpers import get_pagination_page_array
+from webapp.helpers import get_download_url, get_pagination_page_array
 
 
 app = FlaskBase(
@@ -79,6 +79,7 @@ def hardware(canonical_id):
             "bios": model_release["bios"],
             "level": model_release["level"],
             "version": ubuntu_version,
+            "download_url": get_download_url(models[0], model_release),
         }
 
         if release_info["level"] == "Enabled":

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -27,3 +27,38 @@ def get_pagination_page_array(page, total_pages):
         )
 
     return list(range(first_page_to_show, last_page_to_show + 1))
+
+
+def get_download_url(model, model_details):
+    """
+    Return the appropriate ubuntu.com/download url for the model
+
+    :param model: a certifiedmodel resource
+    :param model_details: a certifiedmodeldetails resource
+    :return: appropriate ubuntu.com/download url
+    """
+    platform_category = model.get("category", "").lower()
+    architecture = model_details.get("architecture", "").lower()
+
+    if model_details.get("level") == "Enabled":
+        # Enabled systems use oem images without download links.
+        return
+
+    if platform_category in ["desktop", "laptop"]:
+        return "https://ubuntu.com/download/desktop"
+
+    if "core" in platform_category:
+        return "https://ubuntu.com/download/iot/"
+
+    if "server" in platform_category:
+        # Server platforms have special landing pages based on architecture.
+        arch = ""
+        if "arm" in architecture:
+            arch = "arm"
+        elif "ppc" in architecture:
+            arch = "power"
+        elif "s390x" in architecture:
+            arch = "s390x"
+        return f"https://ubuntu.com/download/server/{arch}"
+
+    return "https://ubuntu.com/download"


### PR DESCRIPTION
This fixes #36.

It also is a little bit more accurate than what happens on the existing site. Our IoT links are broken there.

Examples for different platform categories and architectures can be seen by visiting these pages on the corresponding demo site.

preinstalled does not show
http://0.0.0.0:8034/hardware/201612-25299
https://certification.ubuntu.com/hardware/201612-25299/

desktop http://0.0.0.0:8034/hardware/201802-26090
laptop could not find a laptop that is not in enabled category

core
http://0.0.0.0:8034/hardware/201805-26256 iot

servers
http://0.0.0.0:8034/hardware/201808-26455 plain server
http://0.0.0.0:8034/hardware/201806-26281 x390s
http://0.0.0.0:8034/hardware/201407-15333 arm
http://0.0.0.0:8034/hardware/201805-26248 power
