### PR TITLE
Base hardware detail description on form factor

### DIFF
--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -49,7 +49,7 @@
     <div class="nine-col  last-col device">
       <div class="row row-hero" id="hardware-detail">
         <p class="large">
-          The <strong>{{ vendor }} {{ name }}</strong> {{ category.lower() }}
+          The <strong>{{ vendor }} {{ name }}</strong> {{ form_factor.lower() }}
           with the components described below has been awarded the status of
           certified {% if has_enabled_releases %}pre-install {% endif %}for Ubuntu.
         </p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -103,11 +103,16 @@ def hardware(canonical_id):
     # Build model name
     model_names = [model["model"] for model in models]
 
+    category = models[0]["category"]
+    # default to category, which contains the least specific form_factor
+    form_factor = model_release and model_release.get("form_factor", category)
+
     return flask.render_template(
         "hardware.html",
         canonical_id=canonical_id,
         name=", ".join(model_names),
-        category=models[0]["category"],
+        category=category,
+        form_factor=form_factor,
         vendor=models[0]["make"],
         major_release=models[0]["major_release"],
         hardware_details=hardware_details,


### PR DESCRIPTION
The next certifiedmodeldetails release will include form_factor, which is more specific than category. And fixes the problem where a system is not described accurately, e.g.

iot gateway https://certification.ubuntu.com/hardware/201805-26256/
ubuntu core https://certification.staging.ubuntu.com/hardware/201805-26256