### PR TITLE
Add notes to certificates in /hardware pages

### DIFF
--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -98,7 +98,16 @@
               <p></p>
               <h4>Certification notes</h4>
 
-              <p>There are no notes for this release.</p>
+              {% if release.notes %}
+                <dl>
+                  {% for note in release.notes %}
+                    <dt>{{ note.title }}</dt>
+                    <dd><p>{{ note.comment.replace('\r\n\r\n', '</p><p>') | safe }}</p></dd>
+                  {% endfor %}
+                </dl>
+              {% else %}
+                <p>There are no notes for this release.</p>
+              {% endif %}
 
               {% if release.bios %}
                 <dl id="bios-list">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -78,6 +78,7 @@ def hardware(canonical_id):
             "kernel": model_release["kernel_version"],
             "bios": model_release["bios"],
             "level": model_release["level"],
+            "notes": model_release["notes"],
             "version": ubuntu_version,
             "download_url": get_download_url(models[0], model_release),
         }


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/43 (which is the same as https://bugs.launchpad.net/hexr/+bug/1841966)

QA
--

Go to e.g. `/hardware/201003-5447`, see the notes in all their glory, compare them to https://certification.ubuntu.com/hardware/201003-5447/.