### PR TITLE
Include make in device names on /hardware pages

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -49,7 +49,10 @@ def hardware(canonical_id):
 
     for device in model_devices:
         device_info = {
-            "name": f"{device['make']} {device['name']}",
+            "name": (
+                f"{device['make']} {device['name']}"
+                f" {device['subproduct_name']}"
+            ),
             "bus": device["bus"],
             "identifier": device["identifier"],
         }
@@ -96,10 +99,20 @@ def hardware(canonical_id):
             ):
                 device_category = device_category.capitalize()
 
-                if device_category not in release_details["components"]:
-                    release_details["components"][device_category] = []
+                release_details["components"][device_category] = []
 
-                release_details["components"][device_category] = devices
+                if device_category in release_details["components"]:
+                    for device in devices:
+                        release_details["components"][device_category].append(
+                            {
+                                "name": (
+                                    f"{device['make']} {device['name']}"
+                                    f" {device['subproduct_name']}"
+                                ),
+                                "bus": device["bus"],
+                                "identifier": device["identifier"],
+                            }
+                        )
 
     # Build model name
     model_names = [model["model"] for model in models]


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/44 (née https://bugs.launchpad.net/hexr/+bug/1841963)

QA
--

Go to e.g. `/hardware/201003-5447`, see names that include the make like "Broadcom Corporation NetXtreme II BCM5716 Gigabit Ethernet", as on the live site at https://certification.ubuntu.com/hardware/201003-5447/