### PR TITLE
Encode slashes in identifiers

### DIFF
--- a/templates/catalog/component.html
+++ b/templates/catalog/component.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="row row-hero no-border">
   <div class="container-inner title">
-    <h1>{{ device.name }} <span class="grey">{{ device.category.capitalize() }}</span></h1>
+    <h1>{{ device.make }} {{ device.name }} {{ device.subproduct_name }} <span class="grey">{{ device.category.capitalize() }}</span></h1>
   </div>
   <div class="main">
     <p class="large">

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -130,15 +130,10 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  {% if "/" not in device.identifier %}
-                    {# / breaks the component URLs #}
-                    {% if device.subsystem %}
-                      <a href="/catalog/component/{{ device.subsystem }}/{{ device.identifier }}">{{ device.name }}</a>
-                    {% else %}
-                      <a href="/catalog/component/{{ device.identifier }}">{{ device.name }}</a>
-                    {% endif %}
+                  {% if device.subsystem %}
+                    <a href="/catalog/component/{{ device.subsystem }}/{{ device.identifier.replace('/', '---') }}">{{ device.name }}</a>
                   {% else %}
-                    {{ device.name }}
+                    <a href="/catalog/component/{{ device.identifier.replace('/', '---') }}">{{ device.name }}</a>
                   {% endif %}
                   {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}){% endif %}
                 </p>
@@ -162,15 +157,10 @@
               <td class="details">
                 {% for device in devices %}
                 <p>
-                  {% if "/" not in device.identifier %}
-                    {# / breaks the component URLs #}
-                    {% if device.subsystem %}
-                      <a href="/catalog/component/{{ device.subsystem }}/{{ device.identifier }}">{{ device.name }}</a>
-                    {% else %}
-                      <a href="/catalog/component/{{ device.identifier }}">{{ device.name }}</a>
-                    {% endif %}
+                  {% if device.subsystem %}
+                    <a href="/catalog/component/{{ device.subsystem }}/{{ device.identifier.replace('/', '---') }}">{{ device.name }}</a>
                   {% else %}
-                    {{ device.name }}
+                    <a href="/catalog/component/{{ device.identifier.replace('/', '---') }}">{{ device.name }}</a>
                   {% endif %}
                   {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}){% endif %}
                 </p>
@@ -188,15 +178,10 @@
               <td class="details">
                 {% for device in hardware_details["Other"] %}
                 <p>
-                  {% if "/" not in device.identifier %}
-                    {# / breaks the component URLs #}
-                    {% if device.subsystem %}
-                      <a href="/catalog/component/{{ device.subsystem }}/{{ device.identifier }}">{{ device.name }}</a>
-                    {% else %}
-                      <a href="/catalog/component/{{ device.identifier }}">{{ device.name }}</a>
-                    {% endif %}
+                  {% if device.subsystem %}
+                    <a href="/catalog/component/{{ device.subsystem }}/{{ device.identifier.replace('/', '---') }}">{{ device.name }}</a>
                   {% else %}
-                    {{ device.name }}
+                    <a href="/catalog/component/{{ device.identifier.replace('/', '---') }}">{{ device.name }}</a>
                   {% endif %}
                   {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}){% endif %}
                 </p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -483,7 +483,7 @@ def catalog_component(identifier, subsystem=None):
     page = int(flask.request.args.get("page") or "1")
 
     devices = api.certifiedmodeldevices(
-        identifier=identifier, subsystem=subsystem, limit=0
+        identifier=identifier.replace("---", "/"), subsystem=subsystem, limit=0
     )["objects"]
 
     if not devices:


### PR DESCRIPTION
QA
--

Go to e.g. `/hardware/201810-26535`, see that items with slashes in their identifiers like "HDA Intel PCH HDMI/DP,pcm=10" contain links with slashes replaced with `---`, and that the resulting component pages e.g. `/catalog/component/input:HDAIntelPCHHDMI---DP,pcm=10` work as expected.