### PR TITLE
Implement catalog/search page

### DIFF
--- a/deleted.yaml
+++ b/deleted.yaml
@@ -1,1 +1,1 @@
-catalog/(search|category|makes?)(/.*)?:
+catalog/(category|makes?)(/.*)?:

--- a/templates/catalog/search.html
+++ b/templates/catalog/search.html
@@ -1,0 +1,71 @@
+{% extends '_layout.html' %}
+
+{% block title%}Component Device Details{% endblock %}
+
+{% block content %}
+<div class="row row-hero no-border">
+  <div class="container-inner title">
+    <h1>Component catalog</h1>
+  </div>
+  <div class="main">
+    <div class="pagination">
+      <div class="three-col">
+        <p>{{ total }} results</p>
+      </div>
+      <div class="six-col right last-col">
+        <p class="right">
+          {% with pages=pages, page=page, total_pages=(total / 20), query_string=query_string %}
+          {% include "_pagination.html" %}
+          {% endwith %}
+        </p>
+      </div>
+    </div>
+
+    <div class="twelve-col">
+      <table>
+        <thead>
+          <tr>
+            <th>Make</th>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for device in devices %}
+          <tr>
+            <td>{{ device.make }}</td>
+            <td>
+              <a href="/catalog/component/{{ device.subsystem + '/' if device.subsystem }}{{ device.identifier }}">
+                {{ device.name }} {{ device.subproduct_name }}
+              </a>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="pagination">
+      <div class="three-col">
+        <p>{{ total }} results</p>
+      </div>
+      <div class="six-col right last-col">
+        <p class="right">
+          {% with pages=pages, page=page, total_pages=(total / 20), query_string=query_string %}
+          {% include "_pagination.html" %}
+          {% endwith %}
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="sidebar">
+    <form id="sidebar-search" action="/catalog/search/" method="get" class="body-search">
+      <fieldset>
+        <div id="search">
+            <input id="id_query" type="text" name="query" value="{{ query }}" maxlength="200">
+        </div>
+      </fieldset>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -97,6 +97,7 @@ class CertificationAPI:
         self,
         limit=None,
         offset=None,
+        query=None,
         canonical_id=None,
         identifier=None,
         subsystem=None,
@@ -106,6 +107,7 @@ class CertificationAPI:
             params={
                 "limit": limit,
                 "offset": offset,
+                "query": query,
                 "canonical_id": canonical_id,
                 "identifier": identifier,
                 "subsystem": subsystem,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -509,3 +509,37 @@ def catalog_component(identifier, subsystem=None):
         page=page,
         pages=get_pagination_page_array(page, num_pages),
     )
+
+
+@app.route("/catalog/search")
+def catalog_search():
+    query = flask.request.args.get("query") or ""
+    page = int(flask.request.args.get("page") or "1")
+
+    devices_response = api.certifiedmodeldevices(
+        query=query, offset=(int(page) - 1) * 20
+    )
+
+    devices = devices_response["objects"]
+    total = devices_response["meta"]["total_count"]
+
+    num_pages = math.ceil(total / 20)
+
+    params = flask.request.args.copy()
+    params.pop("page", None)
+
+    query_items = []
+
+    for key, valuelist in params.lists():
+        for value in valuelist:
+            query_items.append(f"{key}={value}")
+
+    return flask.render_template(
+        "catalog/search.html",
+        devices=devices,
+        query=query,
+        total=total,
+        query_string="&".join(query_items),
+        page=page,
+        pages=get_pagination_page_array(page, num_pages),
+    )


### PR DESCRIPTION
@codersquid I've implemented this to query `/api/v1/certifiedmodeldevices/?format=json&query=`, but currently that `query` does nothing, so I think that needs to be implemented API side. If you're happy with the solution though, we could merge this before the API endpoint is ready.

QA
--

Go to `/catalog/search`, compare to https://certification.ubuntu.com/catalog/search, try going through pages, clicking on links. Try searching, see that `query=` is added and it fills in the search box, but it won't filter yet.