### PR TITLE
Support /models endpoint

### DIFF
--- a/templates/models.html
+++ b/templates/models.html
@@ -1,0 +1,151 @@
+{% extends '_layout.html' %}
+
+{% block title%}Ubuntu certified hardware{% endblock %}
+
+{% block content %}
+<nav role="navigation" class="nav-secondary clearfix">
+  <ul class="breadcrumb">
+    <li>
+      <a href="/">
+        Ubuntu Hardware
+      </a>
+    </li>
+    <li>&nbsp;›</li>
+
+    <li class="active">
+      Search Results
+    </li>
+  </ul>
+</nav>
+
+<div class="row row-hero no-border">
+  <div class="container-inner title">
+    <h1>Ubuntu certified hardware</h1>
+  </div>
+
+  <div class="three-col">
+    <form id="sidebar-search" action="" method="get" class="body-search">
+      <fieldset>
+        <div id="search">
+          <input id="id_query" name="query" value="{{ query }}" maxlength="200" type="text" />
+        </div>
+
+        <div id="filter">
+          <p></p>
+          <ul id="id_category">
+            {% for category in all_categories %}
+            <li>
+              <label for="{{ category }}">
+                <input {% if category in categories %}checked="checked"{% endif %} id="category_{{ loop.index }}" name="category" value="{{ category }}" type="checkbox" />
+                {{ category }}s</label>
+            </li>
+            {% endfor %}
+          </ul>
+          <p></p>
+          <p>
+            <label for="id_level">Ubuntu image:</label>
+            <select id="id_level" name="level">
+
+              <option value="">Any</option>
+              {% if level == "Certified"  %}
+              <option value="Certified" selected>Available from ubuntu.com</option>
+              <option value="Enabled">Pre-installed by manufacturer</option>
+              {% elif level == "Enabled" %}
+              <option value="Certified">Available from ubuntu.com</option>
+              <option value="Enabled" selected>Pre-installed by manufacturer</option>
+              {% else %}
+              <option value="Certified">Available from ubuntu.com</option>
+              <option value="Enabled">Pre-installed by manufacturer</option>
+              {% endif %}
+            </select>
+          </p>
+          <p><label for="id_release_0">Release:</label></p>
+          <ul id="id_release">
+            {% for release in all_releases %}
+            <li>
+              <label for="id_release_{{ loop.index }}"><input id="id_release_{{ loop.index }}" name="release"
+                  value="{{ release }}" type="checkbox" {% if release in releases %} checked
+                  {% endif %} />
+                {{ release }}</label>
+            </li>
+            {% endfor %}
+          </ul>
+          <p></p>
+          <p><label for="id_vendors_0">Vendor:</label></p>
+          <ul id="id_vendors">
+            {% for vendor in all_vendors %}
+            <li>
+              <label for="id_vendors_{{ loop.index }}"><input id="id_vendors_{{ loop.index }}" name="vendors"
+                  value="{{ vendor }}" type="checkbox" {% if vendor in vendors %} checked {% endif %} />
+                {{ vendor }}</label>
+            </li>
+            {% endfor %}
+          </ul>
+          <p></p>
+
+          <input value="Update" type="submit" />
+        </div>
+      </fieldset>
+    </form>
+  </div>
+
+  <div class="main">
+    <div class="nine-col  last-col">
+      <p class="large">
+        Canonical works closely with OEMs to certify Ubuntu on a range of
+        their hardware.
+      </p>
+      <p>
+        The following are all certified. More and more devices are being added
+        with each release, so don't forget to check this page regularly.
+      </p>
+      {% if query %}
+      <p>Showing results for "{{ query }}"</p>
+      {% endif %}
+
+      {% if total > 0 %}
+      <div id="models" class="models">
+        <div class="pagination">
+          <div class="three-col">
+            <p>{{ total }} results</p>
+          </div>
+          <div class="six-col right last-col">
+            <p class="right">
+              {% with pages=pages, page=page, total_pages=(total / 20), query_string=query_string %}
+              {% include "_pagination.html" %}
+              {% endwith %}
+            </p>
+          </div>
+        </div>
+        <ul class="model-list">
+          {% for model in models %}
+          <li class="model enabled">
+            <p>
+              {{ model.make }}
+              <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a> {{ model.category }}
+            </p>
+          </li>
+          {% endfor %}
+        </ul>
+
+        <div class="pagination">
+          <div class="three-col">
+            <p>{{ total }} results</p>
+          </div>
+          <div class="six-col right last-col">
+            <p class="right">
+              {% with pages=pages, page=page, total_pages=(total / 20), query_string=query_string %}
+              {% include "_pagination.html" %}
+              {% endwith %}
+            </p>
+          </div>
+        </div>
+      </div>
+      {% else %}
+      <p>No results found.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -412,6 +412,82 @@ def soc_models():
     )
 
 
+@app.route("/models")
+def models():
+    """
+    NOTE: if/when the model list pages are redesigned, consider collapsing all
+    of the /foo/models paths to a generalized /models handler that uses only a
+    generalized models.html template.
+    """
+    query = flask.request.args.get("query") or ""
+    page = int(flask.request.args.get("page") or "1")
+    level = flask.request.args.get("level") or "Any"
+    categories = flask.request.args.getlist("category") or [
+        "Desktop",
+        "Laptop",
+        "Server",
+        "Server SoC",
+        "Ubuntu Core",
+    ]
+    releases = flask.request.args.getlist("release")
+    vendors = flask.request.args.getlist("vendors")
+
+    if level.lower() == "any":
+        level = None
+
+    models_response = api.certifiedmodels(
+        level=level,
+        category__in=",".join(categories),
+        major_release__in=",".join(releases) if releases else None,
+        vendor=vendors,
+        query=query,
+        offset=(int(page) - 1) * 20,
+    )
+    models = models_response["objects"]
+    total = models_response["meta"]["total_count"]
+
+    num_pages = math.ceil(total / 20)
+
+    all_categories = [
+        "Desktop",
+        "Laptop",
+        "Server",
+        "Server SoC",
+        "Ubuntu Core",
+    ]
+    all_releases = [
+        release["release"]
+        for release in api.certifiedreleases(limit="0")["objects"]
+    ]
+    all_vendors = [
+        vendor["make"] for vendor in api.certifiedmakes(limit="0")["objects"]
+    ]
+
+    params = flask.request.args.copy()
+    params.pop("page", None)
+    query_items = []
+    for key, valuelist in params.lists():
+        for value in valuelist:
+            query_items.append(f"{key}={value}")
+
+    return flask.render_template(
+        "models.html",
+        models=models,
+        query=query,
+        level=level,
+        categories=categories,
+        all_categories=all_categories,
+        releases=releases,
+        all_releases=sorted(all_releases, reverse=True),
+        vendors=vendors,
+        all_vendors=sorted(all_vendors),
+        total=total,
+        query_string="&".join(query_items),
+        page=page,
+        pages=get_pagination_page_array(page, num_pages),
+    )
+
+
 @app.route("/components")
 def components():
     query = flask.request.args.get("query") or ""


### PR DESCRIPTION
This change handles the /models endpoint.
The old site had a /models endoint that handled
search categories for most of the category types.
With the turnover 404 counts I can see that we have
users for that page still.

I added a new template that closely resembles the
old template but is better because it supports
options for all of the categories on the navbar and
provides vendor options.

QA:

Go to https://certification-ubuntu-com-canonical-web-and-design-pr-54.run.demo.haus/models and do category and vendor searchs. Verify that the results are filtered on category and vendor.