### PR TITLE
Add more output when black linter fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "watch": "echo 'Nothing to watch'",
     "build": "echo 'Nothing to build'",
     "format-python": "black --line-length 79 webapp",
-    "lint-python": "flake8 webapp && black --check --line-length 79 webapp",
+    "lint-python": "flake8 webapp && black --check --diff --line-length 79 webapp",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "test": "yarn run lint-python"
   }


### PR DESCRIPTION
When `flake8` fails it prints out useful information, but `black` fails without indicated the line numbers that failed, Adding `--diff` provides that information. For example:

without --diff
```
yarn run v1.15.2
warning package.json: No license field
$ yarn run lint-python
warning package.json: No license field
$ flake8 webapp && black --check --line-length 79 webapp
would reformat /home/codersquid/work/certification.ubuntu.com/webapp/app.py
All done! 💥 💔 💥
1 file would be reformatted, 2 files would be left unchanged.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
===
Tests failed
===
```

with --diff

```
yarn run v1.15.2
warning package.json: No license field
$ yarn run lint-python
warning package.json: No license field
$ flake8 webapp && black --check --diff --line-length 79 webapp
--- webapp/app.py       2019-09-06 17:02:53.954152 +0000
+++ webapp/app.py       2019-09-06 17:03:48.976951 +0000
@@ -454,12 +454,12 @@
         "Server",
         "Server SoC",
         "Ubuntu Core",
     ]
     all_releases = [
-        release["release"] for release in api.certifiedreleases(
-            limit="0")["objects"]
+        release["release"]
+        for release in api.certifiedreleases(limit="0")["objects"]
     ]
     all_vendors = [
         vendor["make"] for vendor in api.certifiedmakes(limit="0")["objects"]
     ]
 
would reformat webapp/app.py
All done! 💥 💔 💥
1 file would be reformatted, 2 files would be left unchanged.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
===
Tests failed
===
```