### PR TITLE
Support lowercase in make names

### DIFF
--- a/webapp/api.py
+++ b/webapp/api.py
@@ -34,7 +34,7 @@ class CertificationAPI:
         laptops__gte=None,
         smart_core__gte=None,
         soc__gte=None,
-        make=None,
+        make__iexact=None,
     ):
         return self._get(
             "certifiedmakes",
@@ -45,7 +45,7 @@ class CertificationAPI:
                 "laptops__gte": laptops__gte,
                 "smart_core__gte": smart_core__gte,
                 "soc__gte": soc__gte,
-                "make": make,
+                "make__iexact": make__iexact,
             },
         ).json()
 
@@ -59,6 +59,7 @@ class CertificationAPI:
         canonical_id__in=None,
         major_release__in=None,
         vendor=None,
+        make__iexact=None,
         query=None,
         category__in=None,
         order_by=None,
@@ -71,6 +72,7 @@ class CertificationAPI:
                 "level": level,
                 "major_release__in": major_release__in,
                 "vendor": vendor,
+                "make__iexact": make__iexact,
                 "query": query,
                 "canonical_id": canonical_id,
                 "canonical_id__in": canonical_id__in,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -414,7 +414,7 @@ def soc_models():
 
 @app.route("/make/<make>")
 def make(make):
-    meta = api.certifiedmakes(limit="0", make=make)["meta"]
+    meta = api.certifiedmakes(limit="0", make__iexact=make)["meta"]
     if meta["total_count"] == 0:
         flask.abort(404)
 
@@ -437,7 +437,7 @@ def make(make):
         level=level,
         category__in=",".join(categories),
         major_release__in=",".join(releases) if releases else None,
-        vendor=make,
+        make__iexact=make,
         query=query,
         offset=(int(page) - 1) * 20,
     )


### PR DESCRIPTION
The old site checked for any case in make names.

It didn't handle makes with an spaces and other characters.

The API should be changed to handle normalized makes. For now, this change will handle things like the old site did.

For this case,  we cannot redirect to use the vendor query param because that is too permissive and will return, e.g. Dell and Dell EMC.