### PR TITLE
Enable talisker request metrics

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -3,6 +3,7 @@ import math
 
 # Packages
 import flask
+import talisker.requests
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.http import CachedSession
 
@@ -20,9 +21,10 @@ app = FlaskBase(
     template_500="500.html",
 )
 
+session = CachedSession(timeout=5)
+talisker.requests.configure(session)
 api = CertificationAPI(
-    base_url="https://certification.canonical.com/api/v1",
-    session=CachedSession(timeout=5),
+    base_url="https://certification.canonical.com/api/v1", session=session
 )
 
 


### PR DESCRIPTION
QA
--

`./run --env TALISKER_NETWORKS=TALISKER_NETWORKS=172.17.0.1`

Now go to a few pages, like http://0.0.0.0:8034/iot, http://0.0.0.0:8034/desktop.

Now go to http://0.0.0.0:8034/_status/metrics, check you see lines like:

```
requests_latency_sum{host="certification-canonical-com",status="200",view="unknown"} 2230.151
requests_latency_bucket{host="certification-canonical-com",le="4.0",status="200",view="unknown"} 0.0
requests_latency_bucket{host="certification-canonical-com",le="8.0",status="200",view="unknown"} 0.0
requests_latency_bucket{host="certification-canonical-com",le="16.0",status="200",view="unknown"} 0.0
requests_latency_bucket{host="certification-canonical-com",le="32.0",status="200",view="unknown"} 0.0
requests_latency_bucket{host="certification-canonical-com",le="64.0",status="200",view="unknown"} 0.0
requests_latency_bucket{host="certification-canonical-com",le="128.0",status="200",view="unknown"} 5.0
requests_latency_bucket{host="certification-canonical-com",le="256.0",status="200",view="unknown"} 8.0
requests_latency_bucket{host="certification-canonical-com",le="512.0",status="200",view="unknown"} 8.0
requests_latency_bucket{host="certification-canonical-com",le="1024.0",status="200",view="unknown"} 8.0
requests_latency_bucket{host="certification-canonical-com",le="2048.0",status="200",view="unknown"} 9.0
requests_latency_bucket{host="certification-canonical-com",le="4096.0",status="200",view="unknown"} 9.0
requests_latency_bucket{host="certification-canonical-com",le="8192.0",status="200",view="unknown"} 9.0
requests_latency_bucket{host="certification-canonical-com",le="+Inf",status="200",view="unknown"} 9.0
requests_latency_count{host="certification-canonical-com",status="200",view="unknown"} 9.0
```