### PR TITLE
Rename 'Ubuntu Core' headers to 'Devices'

### DIFF
--- a/templates/iot/index.html
+++ b/templates/iot/index.html
@@ -54,7 +54,7 @@ endblock %} {% block content %}
       <thead>
         <tr>
           <th scope="col">Make</th>
-          <th scope="col">Ubuntu Core</th>
+          <th scope="col">Devices</th>
         </tr>
       </thead>
       <tbody>
@@ -88,7 +88,7 @@ endblock %} {% block content %}
       <thead>
         <tr>
           <th scope="col">Release</th>
-          <th scope="col">Ubuntu Core</th>
+          <th scope="col">Devices</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
We got a request to label Ubuntu Core devices to Devices.

QA

Go to this page https://certification-ubuntu-com-canonical-web-and-design-pr-63.run.demo.haus/iot and verify that the headers are now called 'Devices'