### PR TITLE
Change verbiage on desktop landing page

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -38,8 +38,7 @@
     </p>
     <p class="large">
       The certification chart below highlights OEM partner PCs available
-      preloaded with Ubuntu. Certified OEM images are also available for Ubuntu
-      Advantage customers.
+      preloaded with Ubuntu.
     </p>
 
     <div class="twelve-col cosy-fit">


### PR DESCRIPTION
We got a request to update the page to remove the bit about oem images.

QA by navigating to the /desktops page and verifying that `Certified OEM images are also available for Ubuntu Advantage customers.` has been removed.