### PR TITLE
Show category in breadcrumbs, not Desktop

### DIFF
--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -7,13 +7,13 @@
   <ul class="breadcrumb">
     <li>
       <a href="/desktop">
-        Ubuntu Desktop
+        Ubuntu {{ category }}
       </a>
     </li>
     <li>&nbsp;›</li>
 
     <li>
-      <a href="/desktop/models?category=Desktop">
+        <a href="/desktop/models?category={{ category }}">
         Search Results
       </a>
     </li>


### PR DESCRIPTION
Fixes #68

Causes the breadcrumb for IoT to show
'Ubuntu Ubuntu Core' in the breadcrumb,
but that shuld be a separate issue.

QA: navigate to one of the machine details pages for anything other than desktop and verify that the breadcrumb does not start with "Ubuntu Desktop"