### PR TITLE
Reduce size of docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Don't include caches, logs and documentation
+*.log
+.circleci
+.codecov
+.git
+.github
+.gitignore
+.vscode
+cache.sqlite
+README.md
+HACKING.md
+
+# The run script isn't needed
+run
+.docker-project
+
+# Environemnt
+.env
+.env.local
+
+# Node is only needed for building, not running
+package.json
+node_modules
+yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,15 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # System dependencies
-RUN apt-get update && apt-get install --yes python3-pip
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
 
 # Set git commit ID
 ARG TALISKER_REVISION_ID
 ENV TALISKER_REVISION_ID "${TALISKER_REVISION_ID}"
 
 # Import code, install code dependencies
-ADD . .
-RUN pip3 install -r requirements.txt
+COPY . .
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]


### PR DESCRIPTION
Reduce size of docker image

## QA
- on `master` run `docker build --build-arg REVISION_ID=test -t cert:master .`
- checkout this feature branch
- run `docker build -t cert:feature .`
- run `docker images` and see the image tagged as `feature` is smaller than `master`
- run `docker run -ti -p 8034:80 cert:feature`
- browse localhost:8034 and make sure the site works