### PR TITLE
Use the new api for catalog pages

### DIFF
--- a/webapp/api.py
+++ b/webapp/api.py
@@ -63,6 +63,10 @@ class CertificationAPI:
         query=None,
         category__in=None,
         order_by=None,
+        device_identifier=None,
+        device_bus=None,
+        device_subsystem=None,
+        device_vendor_id=None,
     ):
         response = self._get(
             "certifiedmodels",
@@ -79,6 +83,10 @@ class CertificationAPI:
                 "category": category,
                 "category__in": category__in,
                 "order_by": order_by,
+                "device_identifier": device_identifier,
+                "device_bus": device_bus,
+                "device_subsystem": device_subsystem,
+                "device_vendor_id": device_vendor_id,
             },
         )
         response.raise_for_status()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -631,18 +631,15 @@ def catalog_component(identifier, subsystem=None):
     page = int(flask.request.args.get("page") or "1")
 
     devices = api.certifiedmodeldevices(
-        identifier=identifier.replace("---", "/"), subsystem=subsystem, limit=0
+        identifier=identifier.replace("---", "/"), subsystem=subsystem, limit=1
     )["objects"]
 
     if not devices:
         flask.abort(404)
 
-    canonical_ids = [device["canonical_id"] for device in devices]
-
-    # Only get the first 267 canonical_ids, as the URL will be too long
-    # otherwise
     models_response = api.certifiedmodels(
-        canonical_id__in=",".join(canonical_ids[:267]),
+        device_identifier=identifier,
+        device_subsystem=subsystem,
         offset=(int(page) - 1) * 20,
     )
     models = models_response["objects"]


### PR DESCRIPTION
This uses the new query parameters for certifiedmodels which will return models  that were tested with the specified device parameters.

Fix #83

QA
compare https://certification-ubuntu-com-canonical-web-and-design-pr-84.run.demo.haus/catalog/component/10ec:8168
to https://certification.ubuntu.com/catalog/component/10ec:8168