### PR TITLE
remove category from iot, soc, and server display

### DIFF
--- a/templates/iot/models.html
+++ b/templates/iot/models.html
@@ -113,7 +113,7 @@
           <li class="model enabled">
             <p>
               {{ model.make }}
-              <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a> {{ model.category }}
+              <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a>
             </p>
           </li>
           {% endfor %}

--- a/templates/server/models.html
+++ b/templates/server/models.html
@@ -96,7 +96,7 @@
                     <li class="model enabled">
                         <p>
                             {{ model.make }}
-                            <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a> {{ model.category }}
+                            <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a>
                         </p>
                     </li>
                     {% endfor %}

--- a/templates/soc/models.html
+++ b/templates/soc/models.html
@@ -97,7 +97,7 @@
                     <li class="model enabled">
                         <p>
                             {{ model.make }}
-                            <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a> {{ model.category }}
+                            <a href="/hardware/{{ model.canonical_id }}">{{ model.model }}</a>
                         </p>
                     </li>
                     {% endfor %}


### PR DESCRIPTION
One of the IoT devices has a classic image and not a Core image. We got feedback on how it was listed as a Core device. There is a naming clash with release names and the category of hardware. This is a quick fix for that. I'll open an issue for the ultimate request.

This PR removes the category from everything but the desktop models landing page.

QA

* Laptop and Desktop still show next to models https://certification-ubuntu-com-canonical-web-and-design-pr-85.run.demo.haus/desktop/models?vendors=Dell

Category no longer shows on iot, server, and server soc pages.
* https://certification-ubuntu-com-canonical-web-and-design-pr-85.run.demo.haus/server/models
* https://certification-ubuntu-com-canonical-web-and-design-pr-85.run.demo.haus/iot/models
* https://certification-ubuntu-com-canonical-web-and-design-pr-85.run.demo.haus/soc/models

