### PR TITLE
fixed IoT page title

### DIFF
--- a/templates/iot/models.html
+++ b/templates/iot/models.html
@@ -1,6 +1,6 @@
 {% extends '_layout.html' %}
 
-{% block title%} Ubuntu Server certified hardware{% endblock %}
+{% block title%} Ubuntu IoT certified hardware{% endblock %}
 
 {% block content %}
 <nav role="navigation" class="nav-secondary clearfix">


### PR DESCRIPTION
The title of the IoT model list page had Server instead of IoT.