### PR TITLE
escape the identifier in both api calls

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -630,8 +630,9 @@ def component_details(id):
 def catalog_component(identifier, subsystem=None):
     page = int(flask.request.args.get("page") or "1")
 
+    identifier = identifier.replace("---", "/")
     devices = api.certifiedmodeldevices(
-        identifier=identifier.replace("---", "/"), subsystem=subsystem, limit=1
+        identifier=identifier, subsystem=subsystem, limit=1
     )["objects"]
 
     if not devices:


### PR DESCRIPTION
Fix #97

Results weren't showing for identifiers with slashes because the identifier was only escaped in one place.

verify by seeing results from https://certification-ubuntu-com-105.demos.haus/catalog/component/input:sof-skl_hda_cardHDMI---DP,pcm=11Jack