### PR TITLE
Hardcode 20.04 into components table

### DIFF
--- a/templates/components/index.html
+++ b/templates/components/index.html
@@ -54,6 +54,8 @@
               <th>16.04 LTS</th>
               <th>Core 18</th>
               <th>18.04 LTS</th>
+              <th>Core 20</th>
+              <th>20.04 LTS</th>
               <th>comments</th>
             </tr>
           </thead>
@@ -68,6 +70,8 @@
                 <td>{% if "16.04 LTS" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["16.04 LTS"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
                 <td>{% if "Core 18" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["Core 18"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
                 <td>{% if "18.04 LTS" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["18.04 LTS"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
+                <td>{% if "Core 20" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["Core 20"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
+                <td>{% if "20.04 LTS" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["20.04 LTS"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
                 <td>{{ component.note }}</td>
               </tr>
             {% endfor %}

--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -207,6 +207,8 @@
               <th>16.04 LTS</th>
               <th>Core 18</th>
               <th>18.04 LTS</th>
+              <th>Core 20</th>
+              <th>20.04 LTS</th>
               <th>comments</th>
             </tr>
           </thead>
@@ -221,6 +223,8 @@
                 <td>{% if "16.04 LTS" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["16.04 LTS"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
                 <td>{% if "Core 18" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["Core 18"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
                 <td>{% if "18.04 LTS" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["18.04 LTS"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
+                <td>{% if "Core 20" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["Core 20"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
+                <td>{% if "20.04 LTS" in component.lts_certified_releases %}✔{% if component.lts_certified_releases["20.04 LTS"][0].third_party_driver %}<sup>(1)</sup>{% endif %}{% endif %}</td>
                 <td>{{ component.note }}</td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
See https://certification-ubuntu-com-107.demos.haus/components

I tried adding `overflow-x: scroll` to the wrapping div, but since the scrollbar appears at the bottom, out of sight, I thought it just looks just as broken as without it, but the useful content is hidden.

![image](https://user-images.githubusercontent.com/519935/89881106-f4771180-dbbc-11ea-8398-61cdc59e5eed.png)

So I think maybe the best quick fix is without the horizontal scrolling for now, exactly as @codersquid wrote it.

Helps with #106