### PR TITLE
Fixes “View all component devices” link

### DIFF
--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -234,7 +234,7 @@
           <li>(1) Third party driver may be required.</li>
         </ul>
 
-        <a class="p-button--neutral" href="/components?query={{ canonical_id }}">View all component devices</a>
+        <a class="p-button--neutral" href="/components?canonical_id={{ canonical_id }}">View all component devices</a>
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
Fixes #55.

(Yes, the site is due to be replaced, but this is a one-line fix that makes existing pages much easier to visit.)