### PR TITLE
add canonical id to feedback questions

### DIFF
--- a/templates/hardware.html
+++ b/templates/hardware.html
@@ -38,7 +38,7 @@
       <p>
         If there is an issue with the information for this system, please
         <a target="_blank"
-          href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the {{vendor}} {{ name }}">
+           href="https://answers.launchpad.net/ubuntu-certification/+addquestion?field.title=Feedback on the {{vendor}} {{ name }} ({{ canonical_id }})">
           let us know
         </a>.
       </p>


### PR DESCRIPTION
When a user clicks on the feedback link,
the canonical id of the machine will be
included in the subject line of the question.

This satisfies #124.