### PR TITLE
Fix grammar in /iot

### DIFF
--- a/templates/iot/index.html
+++ b/templates/iot/index.html
@@ -20,7 +20,7 @@ endblock %} {% block content %}
     <p class="large">
       IoT devices certification guarantees that IoT devices are supported in
       Ubuntu releases. Our engineering teams work with IoT device vendors to
-      enablement hardware, stabilize the core system, and verify specific
+      enable hardware, stabilize the core system, and verify specific
       applications and workloads function optimally on the platform.
     </p>
     <p class="large">


### PR DESCRIPTION
## Done

- Fix grammar - replace 'enablement' with 'enable'

## QA

1. go to http://0.0.0.0:8034/iot
2. See that it says 'enable' not 'enablement'

Fixes #128