### PR TITLE
Fix missing statuses on component page

### DIFF
--- a/templates/components/details.html
+++ b/templates/components/details.html
@@ -60,7 +60,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for name, details in component.lts_certified_releases.items() %}
+            {% for name, details in component.lts_releases.items() %}
               <tr>
                 <td>{{ details.0.status.title() }}</td>
                 <td>{{ details.0.release }}</td>


### PR DESCRIPTION
The statuses weren't showing up on the component
details page because it was looking for them in
a deprecated field.

you can check the results by navigating to https://certification-ubuntu-com-172.demos.haus/components/682 to see the status show up in the status table.